### PR TITLE
Align leaderboard socket events and surface live-update diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Run these before committing to reduce hook timeouts.
    - `gameStart` - Game begins
    - `gameUpdate` - Ball/paddle positions (60 times/second)
    - `gameOver` - Match results and rating changes
-   - `leaderboardUpdate` - Live ranking updates
+   - `leaderboardUpdate` - Live ranking updates (aliases legacy `rankingsUpdate`)
 
 #### 2. Backend Layer (Node.js + Socket.IO)
 

--- a/README.md
+++ b/README.md
@@ -658,3 +658,5 @@ This project is licensed under the MIT License. See the LICENSE file for details
 - Original Pong game by Atari (1972)
 - Socket.IO for real-time communication
 - Docker for containerization
+
+- [Socket Events](docs/socket-events.md)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Run these before committing to reduce hook timeouts.
    - `gameStart` - Game begins
    - `gameUpdate` - Ball/paddle positions (60 times/second)
    - `gameOver` - Match results and rating changes
-   - `leaderboardUpdate` - Live ranking updates (aliases legacy `rankingsUpdate`)
+   - `leaderboardUpdate (aka rankingsUpdate)` - Live ranking updates
 
 #### 2. Backend Layer (Node.js + Socket.IO)
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ pnpm dev
 
 ### Frontend
 
+> Debug tip: set `REACT_APP_DEBUG_SOCKET_EVENTS=true` to log leaderboard alias events in the browser console.
+
 - React 18
 - Socket.IO Client
 - React Router v6

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Run these before committing to reduce hook timeouts.
    - Calculate ELO changes
    - Update Player Service
    - Emit `gameOver` with results
-   - Broadcast `leaderboardUpdate` to all clients
+   - Broadcast `leaderboardUpdate` (legacy alias `rankingsUpdate`) to all clients
 
 **Why Server-Side Game Logic?**
 

--- a/STARTUP_GUIDE.md
+++ b/STARTUP_GUIDE.md
@@ -59,6 +59,7 @@ Enter your username and start playing!
 | Frontend (`frontend/.env`)      | `REACT_APP_BACKEND_URL` | Browser (React)  | `http://localhost:8080`      | Used for Socket.IO + REST calls. Change to the Fly.io / Base URL when deploying. |
 
 Even without this variable the frontend now tries to infer the backend URL (mapping http://localhost:3000 → http://localhost:8080) and shows an in-app warning banner if it cannot reach the server. Setting the env var explicitly is still the most predictable approach for staging/production.
+Add `REACT_APP_DEBUG_SOCKET_EVENTS=true` locally if you want the console to log every leaderboard alias event for troubleshooting.
 | Frontend                        | `FRONTEND_PORT`         | Local dev server | `3000`                       | Matches the port exposed in `docker-compose.yml`.                                |
 | Backend (`backend/.env`)        | `PLAYER_SERVICE_URL`    | Node service     | `http://player-service:5001` | Replace with `http://localhost:5001` when running everything outside Docker.     |
 | Backend                         | `BACKEND_PORT`          | Node service     | `8080`                       | Must stay in sync with `frontend/.env` target.                                   |

--- a/backend/README.md
+++ b/backend/README.md
@@ -41,7 +41,7 @@ The server exposes a single namespace using the default path (`/socket.io/`). No
 | `paddleMove`                                                              | client → server | `{ roomCode, direction }` | Forwarded to physics loop at 60 FPS.                                    |
 | `pauseGame` / `forfeitGame`                                               | client → server | `void`                    | Controlled game state changes; results broadcast via `gameState`.       |
 | `requestRematch`/`rematchResponse`                                        | bidirectional   | metadata                  | Negotiates rematch using existing room.                                 |
-| `getLeaderboard`                                                          | client → server | `void`                    | Emits `leaderboardUpdate` with top 10.                                  |
+| `getLeaderboard`                                                          | client → server | `void`                    | Emits `leaderboardUpdate` (aliases `rankingsUpdate`) with top 10.       |
 | `roomCreated`, `roomReady`, `waitingForPlayer2Stake`, `stakedMatchJoined` | server → client | metadata                  | Lifecycle notifications for UI flows.                                   |
 
 See `multiplayerHandler.js` for the authoritative list.

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,26 +4,26 @@ Socket.IO + Express lives here. This service orchestrates matchmaking, physics, 
 
 ## Key commands
 
-| Command | Description |
-| --- | --- |
-| `pnpm install` | Install workspace dependencies. |
-| `pnpm dev` | Start the API + Socket.IO server on `http://localhost:8080`. |
-| `pnpm lint` | Run ESLint for this package. |
+| Command               | Description                                                                     |
+| --------------------- | ------------------------------------------------------------------------------- |
+| `pnpm install`        | Install workspace dependencies.                                                 |
+| `pnpm dev`            | Start the API + Socket.IO server on `http://localhost:8080`.                    |
+| `pnpm lint`           | Run ESLint for this package.                                                    |
 | `pnpm player-service` | Launches the lightweight leaderboard/player service that shares this workspace. |
 
 ## HTTP API surface
 
-| Method | Path | Description |
-| --- | --- | --- |
-| `GET` | `/health` | Readiness probe with timestamp + environment echo. |
-| `GET` | `/players` | Full leaderboard sorted by ELO. |
-| `GET` | `/players/top?limit=10` | Top `limit` players. Aliased under `/rankings` and `/api/rankings/top`. |
-| `GET` | `/players/:name` | Player profile (wins/losses, rating). Also exposed at `/api/players/:name`. |
-| `POST` | `/players` | Create or upsert a player record (name, result metadata). |
-| `PATCH` | `/players/:name/rating` | Persist new rating + optional win/loss outcome. |
-| `POST` | `/games` | Create/update a game session; triggers winner signature for staked matches. |
-| `GET` | `/games/my-wins?address=0x...` | Paginated list of staked wins for claim UI. |
-| `POST` | `/games/:gameId/claimed` | Mark a win as claimed (tx hash required). |
+| Method  | Path                           | Description                                                                 |
+| ------- | ------------------------------ | --------------------------------------------------------------------------- |
+| `GET`   | `/health`                      | Readiness probe with timestamp + environment echo.                          |
+| `GET`   | `/players`                     | Full leaderboard sorted by ELO.                                             |
+| `GET`   | `/players/top?limit=10`        | Top `limit` players. Aliased under `/rankings` and `/api/rankings/top`.     |
+| `GET`   | `/players/:name`               | Player profile (wins/losses, rating). Also exposed at `/api/players/:name`. |
+| `POST`  | `/players`                     | Create or upsert a player record (name, result metadata).                   |
+| `PATCH` | `/players/:name/rating`        | Persist new rating + optional win/loss outcome.                             |
+| `POST`  | `/games`                       | Create/update a game session; triggers winner signature for staked matches. |
+| `GET`   | `/games/my-wins?address=0x...` | Paginated list of staked wins for claim UI.                                 |
+| `POST`  | `/games/:gameId/claimed`       | Mark a win as claimed (tx hash required).                                   |
 
 > Tip: use Thunder Client / Insomnia collections stored in `docs/` (planned in a later chunk) or curl against `localhost:8080` after `pnpm dev`.
 
@@ -31,30 +31,30 @@ Socket.IO + Express lives here. This service orchestrates matchmaking, physics, 
 
 The server exposes a single namespace using the default path (`/socket.io/`). Notable events:
 
-| Event | Direction | Payload | Notes |
-| --- | --- | --- | --- |
-| `createRoom` | client → server | `{ player, roomCode? }` | Creates a private room. Optional `roomCode` for staked escrow sessions. |
-| `joinRoom` | client → server | `{ roomCode, player }` | Joins existing room, triggers `roomReady` when both players present. |
-| `findRandomMatch` | client → server | `{ player }` | Starts matchmaking queue for public games. |
-| `spectateGame` | client → server | `{ roomCode }` | Adds socket to spectator list; server emits `spectatorUpdate`. |
-| `getActiveGames` | client → server | `void` | Returns `{ games: [...] }` via `activeGamesList`. |
-| `paddleMove` | client → server | `{ roomCode, direction }` | Forwarded to physics loop at 60 FPS. |
-| `pauseGame` / `forfeitGame` | client → server | `void` | Controlled game state changes; results broadcast via `gameState`. |
-| `requestRematch`/`rematchResponse` | bidirectional | metadata | Negotiates rematch using existing room. |
-| `getLeaderboard` | client → server | `void` | Emits `leaderboardUpdate` with top 10. |
-| `roomCreated`, `roomReady`, `waitingForPlayer2Stake`, `stakedMatchJoined` | server → client | metadata | Lifecycle notifications for UI flows. |
+| Event                                                                     | Direction       | Payload                   | Notes                                                                   |
+| ------------------------------------------------------------------------- | --------------- | ------------------------- | ----------------------------------------------------------------------- |
+| `createRoom`                                                              | client → server | `{ player, roomCode? }`   | Creates a private room. Optional `roomCode` for staked escrow sessions. |
+| `joinRoom`                                                                | client → server | `{ roomCode, player }`    | Joins existing room, triggers `roomReady` when both players present.    |
+| `findRandomMatch`                                                         | client → server | `{ player }`              | Starts matchmaking queue for public games.                              |
+| `spectateGame`                                                            | client → server | `{ roomCode }`            | Adds socket to spectator list; server emits `spectatorUpdate`.          |
+| `getActiveGames`                                                          | client → server | `void`                    | Returns `{ games: [...] }` via `activeGamesList`.                       |
+| `paddleMove`                                                              | client → server | `{ roomCode, direction }` | Forwarded to physics loop at 60 FPS.                                    |
+| `pauseGame` / `forfeitGame`                                               | client → server | `void`                    | Controlled game state changes; results broadcast via `gameState`.       |
+| `requestRematch`/`rematchResponse`                                        | bidirectional   | metadata                  | Negotiates rematch using existing room.                                 |
+| `getLeaderboard`                                                          | client → server | `void`                    | Emits `leaderboardUpdate` with top 10.                                  |
+| `roomCreated`, `roomReady`, `waitingForPlayer2Stake`, `stakedMatchJoined` | server → client | metadata                  | Lifecycle notifications for UI flows.                                   |
 
 See `multiplayerHandler.js` for the authoritative list.
 
 ## Local development workflow
 
 1. Copy `.env.example` → `.env` (at repo root or inside `backend/`) and set:
-	- `FRONTEND_URL=http://localhost:3000`
-	- `MONGODB_URI=mongodb://localhost:27017/pong-it`
+   - `FRONTEND_URL=http://localhost:3000`
+   - `MONGODB_URI=mongodb://localhost:27017/pong-it`
 2. Start Mongo locally (`docker compose up mongo` or Atlas connection).
 3. Run `pnpm dev` and watch the console for:
-	- `✓ Connected to MongoDB`
-	- `Server running on port 8080` (from `test-server.js` or `server.js` logs)
+   - `✓ Connected to MongoDB`
+   - `Server running on port 8080` (from `test-server.js` or `server.js` logs)
 4. (Optional) Start the standalone player service via `pnpm player-service` if you want the ELO map persisted separately.
 
 Hot reload is provided by `nodemon` via `pnpm dev`, so edits to `src/*.js` restart automatically.
@@ -70,3 +70,5 @@ Hot reload is provided by `nodemon` via `pnpm dev`, so edits to `src/*.js` resta
 
 - Review `gameManager.js`, `roomManager.js`, and `leaderboardManager.js` to understand how state moves between memory, MongoDB, and socket rooms.
 - `services/signatureService.js` signs escrow winners; ensure the signer key lives in `.env` before enabling staked matches.
+
+> Debug tip: set `DEBUG_SOCKET_EVENTS=true` to log every leaderboard alias emission, which helps confirm clients receive both `leaderboardUpdate` and `rankingsUpdate` events during migration.

--- a/backend/src/constants/socketEvents.js
+++ b/backend/src/constants/socketEvents.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/backend/src/constants/socketEvents.js
+++ b/backend/src/constants/socketEvents.js
@@ -1,1 +1,3 @@
-module.exports = {};
+module.exports = {
+  LEADERBOARD_UPDATE: 'leaderboardUpdate'
+};

--- a/backend/src/constants/socketEvents.js
+++ b/backend/src/constants/socketEvents.js
@@ -1,7 +1,7 @@
-const SOCKET_EVENTS = {
+const SOCKET_EVENTS = Object.freeze({
   LEADERBOARD_UPDATE: 'leaderboardUpdate',
   RANKINGS_UPDATE: 'rankingsUpdate'
-};
+});
 
 const getLeaderboardEvents = () => [
   SOCKET_EVENTS.LEADERBOARD_UPDATE,

--- a/backend/src/constants/socketEvents.js
+++ b/backend/src/constants/socketEvents.js
@@ -1,4 +1,14 @@
-module.exports = {
+const SOCKET_EVENTS = {
   LEADERBOARD_UPDATE: 'leaderboardUpdate',
   RANKINGS_UPDATE: 'rankingsUpdate'
+};
+
+const getLeaderboardEvents = () => [
+  SOCKET_EVENTS.LEADERBOARD_UPDATE,
+  SOCKET_EVENTS.RANKINGS_UPDATE
+];
+
+module.exports = {
+  SOCKET_EVENTS,
+  getLeaderboardEvents
 };

--- a/backend/src/constants/socketEvents.js
+++ b/backend/src/constants/socketEvents.js
@@ -1,3 +1,4 @@
 module.exports = {
-  LEADERBOARD_UPDATE: 'leaderboardUpdate'
+  LEADERBOARD_UPDATE: 'leaderboardUpdate',
+  RANKINGS_UPDATE: 'rankingsUpdate'
 };

--- a/backend/src/multiplayerHandler.js
+++ b/backend/src/multiplayerHandler.js
@@ -80,7 +80,7 @@ class MultiplayerHandler {
 
     socket.on('getLeaderboard', async () => {
       const leaderboard = await this.leaderboardManager.getTopPlayers(10);
-      socket.emit('leaderboardUpdate', leaderboard);
+      emitLeaderboardUpdate(socket, leaderboard);
     });
 
     if (username) {

--- a/backend/src/multiplayerHandler.js
+++ b/backend/src/multiplayerHandler.js
@@ -3,6 +3,7 @@ const GameManager = require('./gameManager');
 const LeaderboardManager = require('./leaderboardManager');
 const Game = require('./models/Game');
 const signatureService = require('./services/signatureService');
+const emitLeaderboardUpdate = require('./utils/emitLeaderboardUpdate');
 
 class MultiplayerHandler {
   constructor(io) {

--- a/backend/src/multiplayerHandler.js
+++ b/backend/src/multiplayerHandler.js
@@ -364,7 +364,7 @@ class MultiplayerHandler {
     this.io.to(roomCode).emit('gameOver', gameOverData);
 
     const leaderboard = await this.leaderboardManager.getTopPlayers(10);
-    this.io.emit('leaderboardUpdate', leaderboard);
+    emitLeaderboardUpdate(this.io, leaderboard);
 
     this.endGame(roomCode);
   }

--- a/backend/src/utils/emitLeaderboardUpdate.js
+++ b/backend/src/utils/emitLeaderboardUpdate.js
@@ -1,7 +1,11 @@
 const { getLeaderboardEvents } = require('../constants/socketEvents');
 
-module.exports = function emitLeaderboardUpdate(io, payload) {
+module.exports = function emitLeaderboardUpdate(emitter, payload) {
+  if (!emitter || typeof emitter.emit !== 'function') {
+    throw new Error('Emitter must expose an emit(event, payload) function');
+  }
+
   getLeaderboardEvents().forEach((eventName) => {
-    io.emit(eventName, payload);
+    emitter.emit(eventName, payload);
   });
 };

--- a/backend/src/utils/emitLeaderboardUpdate.js
+++ b/backend/src/utils/emitLeaderboardUpdate.js
@@ -1,11 +1,16 @@
 const { getLeaderboardEvents } = require('../constants/socketEvents');
 
+const shouldLogEvents = process.env.DEBUG_SOCKET_EVENTS === 'true';
+
 module.exports = function emitLeaderboardUpdate(emitter, payload) {
   if (!emitter || typeof emitter.emit !== 'function') {
     throw new Error('Emitter must expose an emit(event, payload) function');
   }
 
   getLeaderboardEvents().forEach((eventName) => {
+    if (shouldLogEvents && console?.info) {
+      console.info('[socket] emitting %s', eventName);
+    }
     emitter.emit(eventName, payload);
   });
 };

--- a/backend/src/utils/emitLeaderboardUpdate.js
+++ b/backend/src/utils/emitLeaderboardUpdate.js
@@ -1,5 +1,9 @@
 const { getLeaderboardEvents } = require('../constants/socketEvents');
 
+/**
+ * Emits leaderboard updates using both canonical and legacy event names.
+ * Pass either the Socket.IO server or an individual socket.
+ */
 const shouldLogEvents = process.env.DEBUG_SOCKET_EVENTS === 'true';
 
 module.exports = function emitLeaderboardUpdate(emitter, payload) {

--- a/backend/src/utils/emitLeaderboardUpdate.js
+++ b/backend/src/utils/emitLeaderboardUpdate.js
@@ -1,0 +1,7 @@
+const { getLeaderboardEvents } = require('../constants/socketEvents');
+
+module.exports = function emitLeaderboardUpdate(io, payload) {
+  getLeaderboardEvents().forEach((eventName) => {
+    io.emit(eventName, payload);
+  });
+};

--- a/docs/socket-events.md
+++ b/docs/socket-events.md
@@ -1,0 +1,8 @@
+# Socket Events
+
+| Event                 | Notes                                 |
+|----------------------|----------------------------------------|
+| `leaderboardUpdate`  | Canonical leaderboard broadcast.       |
+| `rankingsUpdate`     | Legacy alias kept for older clients.   |
+
+Both are emitted together until the new name lands everywhere.

--- a/docs/socket-events.md
+++ b/docs/socket-events.md
@@ -6,3 +6,8 @@
 | `rankingsUpdate`     | Legacy alias kept for older clients.   |
 
 Both are emitted together until the new name lands everywhere.
+
+## Debugging
+
+- Backend: set `DEBUG_SOCKET_EVENTS=true` to trace emits.
+- Frontend: set `REACT_APP_DEBUG_SOCKET_EVENTS=true` to log listeners.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -60,3 +60,4 @@ frontend/
 - `frontend/src/hooks/useContract.js` wraps wagmi for the escrow contract; update the address in `src/constants.js` when redeploying.
 - Canvas physics are authoritative from the backend, so keep UI optimizations pure (no extra physics on the client).
 - If `REACT_APP_BACKEND_URL` is missing the UI now infers it (mapping port 3000 → 8080) and shows a banner with retry controls; still set the var explicitly in CI/staging so sockets always hit the right host.
+- Set `REACT_APP_DEBUG_SOCKET_EVENTS=true` when you want the console to log every leaderboard alias event delivered to the Welcome screen.

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -83,11 +83,6 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
       socket.emit('getActiveGames');
     });
 
-    socket.on('rankingsUpdate', (newRankings) => {
-      console.log('Received rankings update:', newRankings);
-      setRankings(newRankings);
-    });
-
     socket.on('activeGamesList', (games) => {
       console.log('Received active games:', games);
       setActiveGames(games);

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -22,6 +22,7 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
   const titleRef = useRef();
   const navigate = useNavigate();
   const socketRef = useRef(null);
+  const [socketInstance, setSocketInstance] = useState(null);
 
   // Web3 hooks
   const { open } = useAppKit();

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -655,8 +655,10 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
         
         <div className="rankings">
           <h2>Top Players</h2>
-          {lastLeaderboardEvent && (
+          {lastLeaderboardEvent ? (
             <p className="rankings-event">Live via {lastLeaderboardEvent}</p>
+          ) : (
+            <p className="rankings-event pending">Waiting for live updates...</p>
           )}
           <div className="rankings-list">
             {rankings.length > 0 ? (

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -655,6 +655,9 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
         
         <div className="rankings">
           <h2>Top Players</h2>
+          {lastLeaderboardEvent && (
+            <p className="rankings-event">Live via {lastLeaderboardEvent}</p>
+          )}
           <div className="rankings-list">
             {rankings.length > 0 ? (
               rankings.map((player, index) => (

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -23,12 +23,19 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
   const titleRef = useRef();
   const navigate = useNavigate();
   const socketRef = useRef(null);
+  const leaderboardPayloadRef = useRef(null);
   const [socketInstance, setSocketInstance] = useState(null);
 
   const handleLeaderboardUpdate = useCallback((newRankings) => {
     console.log('Received leaderboard update:', newRankings);
-    setRankings(Array.isArray(newRankings) ? newRankings : []);
-  }, []);
+    const normalized = Array.isArray(newRankings) ? newRankings : [];
+    const serialized = JSON.stringify(normalized);
+    if (leaderboardPayloadRef.current === serialized) {
+      return;
+    }
+    leaderboardPayloadRef.current = serialized;
+    setRankings(normalized);
+  }, [leaderboardPayloadRef]);
 
 
   // Web3 hooks

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -104,6 +104,8 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
     };
   }, []);
 
+  useLeaderboardUpdates(socketInstance, handleLeaderboardUpdate);
+
   // Add handler to start audio after user interaction
   const handleStartAudio = useCallback(() => {
     if (!audioStarted) {

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -24,6 +24,12 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
   const socketRef = useRef(null);
   const [socketInstance, setSocketInstance] = useState(null);
 
+  const handleLeaderboardUpdate = useCallback((newRankings) => {
+    console.log('Received leaderboard update:', newRankings);
+    setRankings(Array.isArray(newRankings) ? newRankings : []);
+  }, []);
+
+
   // Web3 hooks
   const { open } = useAppKit();
   const { address, isConnected } = useAccount();

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -93,6 +93,7 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
 
     return () => {
       clearInterval(gamesInterval);
+      setSocketInstance(null);
       socket.disconnect();
     };
   }, []);

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -656,9 +656,9 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
         <div className="rankings">
           <h2>Top Players</h2>
           {lastLeaderboardEvent ? (
-            <p className="rankings-event">Live via {lastLeaderboardEvent}</p>
+            <p className="rankings-event" data-testid="leaderboard-event">Live via {lastLeaderboardEvent}</p>
           ) : (
-            <p className="rankings-event pending">Waiting for live updates...</p>
+            <p className="rankings-event pending" data-testid="leaderboard-event">Waiting for live updates...</p>
           )}
           <div className="rankings-list">
             {rankings.length > 0 ? (

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -70,6 +70,7 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
     });
 
     socketRef.current = socket;
+    setSocketInstance(socket);
 
     socket.on('connect', () => {
       console.log('Socket connected');

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -100,7 +100,7 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
     };
   }, []);
 
-  useLeaderboardUpdates(socketInstance, handleLeaderboardUpdate);
+  useLeaderboardUpdates(socketInstance, handleLeaderboardUpdate, setLastLeaderboardEvent);
 
   // Add handler to start audio after user interaction
   const handleStartAudio = useCallback(() => {

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -8,6 +8,7 @@ import { buildBackendUrl } from '../utils/backendClient';
 import soundManager from '../utils/soundManager';
 import { useStakeAsPlayer1, useStakeAsPlayer2, useGetMatch } from '../hooks/useContract';
 import { STAKE_AMOUNTS } from '../contracts/PongEscrow';
+import { useLeaderboardUpdates } from '../hooks/useLeaderboardUpdates';
 
 const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
   const [rankings, setRankings] = useState([]);

--- a/frontend/src/components/Welcome.js
+++ b/frontend/src/components/Welcome.js
@@ -18,6 +18,7 @@ const Welcome = ({ setGameState, savedUsername, onUsernameSet }) => {
   const [stakingInProgress, setStakingInProgress] = useState(false);
   const [selectedStakeAmount, setSelectedStakeAmount] = useState(null);
   const [pendingRoomCode, setPendingRoomCode] = useState(null);
+  const [lastLeaderboardEvent, setLastLeaderboardEvent] = useState(null);
   const [stakingErrorMessage, setStakingErrorMessage] = useState(null);
   const titleRef = useRef();
   const navigate = useNavigate();

--- a/frontend/src/constants/socketEvents.js
+++ b/frontend/src/constants/socketEvents.js
@@ -1,0 +1,1 @@
+export const SOCKET_EVENTS = {};

--- a/frontend/src/constants/socketEvents.js
+++ b/frontend/src/constants/socketEvents.js
@@ -1,1 +1,4 @@
-export const SOCKET_EVENTS = {};
+export const SOCKET_EVENTS = {
+  LEADERBOARD_UPDATE: 'leaderboardUpdate',
+  RANKINGS_UPDATE: 'rankingsUpdate'
+};

--- a/frontend/src/constants/socketEvents.js
+++ b/frontend/src/constants/socketEvents.js
@@ -1,7 +1,7 @@
-export const SOCKET_EVENTS = {
+export const SOCKET_EVENTS = Object.freeze({
   LEADERBOARD_UPDATE: 'leaderboardUpdate',
   RANKINGS_UPDATE: 'rankingsUpdate'
-};
+});
 
 export const LEADERBOARD_EVENTS = [
   SOCKET_EVENTS.LEADERBOARD_UPDATE,

--- a/frontend/src/constants/socketEvents.js
+++ b/frontend/src/constants/socketEvents.js
@@ -2,3 +2,8 @@ export const SOCKET_EVENTS = {
   LEADERBOARD_UPDATE: 'leaderboardUpdate',
   RANKINGS_UPDATE: 'rankingsUpdate'
 };
+
+export const LEADERBOARD_EVENTS = [
+  SOCKET_EVENTS.LEADERBOARD_UPDATE,
+  SOCKET_EVENTS.RANKINGS_UPDATE
+];

--- a/frontend/src/hooks/useLeaderboardUpdates.js
+++ b/frontend/src/hooks/useLeaderboardUpdates.js
@@ -1,0 +1,1 @@
+export const useLeaderboardUpdates = () => {};

--- a/frontend/src/hooks/useLeaderboardUpdates.js
+++ b/frontend/src/hooks/useLeaderboardUpdates.js
@@ -2,6 +2,10 @@ import { useEffect } from 'react';
 import { LEADERBOARD_EVENTS } from '../constants/socketEvents';
 import { logSocketEvent } from '../utils/socketEventLogger';
 
+/**
+ * Subscribes to leaderboard socket events (new + legacy) and funnels them
+ * through a single handler, optionally reporting which event fired.
+ */
 export const useLeaderboardUpdates = (socket, onUpdate, onEventName) => {
   useEffect(() => {
     if (!socket || typeof onUpdate !== 'function') {

--- a/frontend/src/hooks/useLeaderboardUpdates.js
+++ b/frontend/src/hooks/useLeaderboardUpdates.js
@@ -12,6 +12,10 @@ export const useLeaderboardUpdates = (socket, onUpdate, onEventName) => {
       return undefined;
     }
 
+    if (typeof socket.on !== 'function' || typeof socket.off !== 'function') {
+      return undefined;
+    }
+
     const listeners = new Map();
 
     LEADERBOARD_EVENTS.forEach((eventName) => {

--- a/frontend/src/hooks/useLeaderboardUpdates.js
+++ b/frontend/src/hooks/useLeaderboardUpdates.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { LEADERBOARD_EVENTS } from '../constants/socketEvents';
+import { logSocketEvent } from '../utils/socketEventLogger';
 
 export const useLeaderboardUpdates = (socket, onUpdate, onEventName) => {
   useEffect(() => {

--- a/frontend/src/hooks/useLeaderboardUpdates.js
+++ b/frontend/src/hooks/useLeaderboardUpdates.js
@@ -1,1 +1,20 @@
-export const useLeaderboardUpdates = () => {};
+import { useEffect } from 'react';
+import { LEADERBOARD_EVENTS } from '../constants/socketEvents';
+
+export const useLeaderboardUpdates = (socket, onUpdate) => {
+  useEffect(() => {
+    if (!socket || typeof onUpdate !== 'function') {
+      return undefined;
+    }
+
+    LEADERBOARD_EVENTS.forEach((eventName) => {
+      socket.on(eventName, onUpdate);
+    });
+
+    return () => {
+      LEADERBOARD_EVENTS.forEach((eventName) => {
+        socket.off(eventName, onUpdate);
+      });
+    };
+  }, [socket, onUpdate]);
+};

--- a/frontend/src/styles/Welcome.css
+++ b/frontend/src/styles/Welcome.css
@@ -801,3 +801,8 @@ dialog.stake-modal h2 {
     font-size: 0.8rem;
   }
 } 
+.rankings-event {
+  font-size: 0.9rem;
+  margin: 4px 0 8px;
+  color: #8cc0ff;
+}

--- a/frontend/src/styles/Welcome.css
+++ b/frontend/src/styles/Welcome.css
@@ -806,3 +806,8 @@ dialog.stake-modal h2 {
   margin: 4px 0 8px;
   color: #8cc0ff;
 }
+
+.rankings-event.pending {
+  opacity: 0.7;
+  font-style: italic;
+}

--- a/frontend/src/utils/socketEventLogger.js
+++ b/frontend/src/utils/socketEventLogger.js
@@ -1,0 +1,11 @@
+const shouldLogSocketEvents = process.env.REACT_APP_DEBUG_SOCKET_EVENTS === 'true';
+
+export const logSocketEvent = (eventName, payload) => {
+  if (!shouldLogSocketEvents) {
+    return;
+  }
+
+  if (typeof console !== 'undefined') {
+    console.info('[socket]', eventName, payload);
+  }
+};

--- a/issues.md
+++ b/issues.md
@@ -10,7 +10,7 @@
 - [ ] **Rematch accept routes to `/multiplayer` which doesn’t exist** – `GameOver` navigates to `/multiplayer` even though the router only defines `/game`, so accept rematch shows a blank screen. _(Label: Bug)_
 - [ ] **Rematch sockets never reach the server** – The gameplay socket disconnects before `GameOver` opens a new socket, so backend handlers can’t find the room and rematches never start. _(Label: Bug)_
 - [ ] **Socket handshake logs leak sensitive data** – `backend/src/server.js` logs entire request headers, exposing cookies/tokens in logs; remove or scrub them. _(Label: Security)_
-- [ ] **Leaderboard never refreshes over WebSocket** – Frontend listens for `rankingsUpdate` while backend emits `leaderboardUpdate`, so live updates never arrive. _(Label: Bug)_
+- [x] **Leaderboard never refreshes over WebSocket** – Backend now emits both `leaderboardUpdate` and its `rankingsUpdate` alias while the frontend listens to both via a shared hook + UI badge, so live updates flow again. _(Label: Bug)_
 - [ ] **Local leaderboard cache is never updated** – Ratings stored in `playerRankings` stay at 1000 because `updatePlayerRanking` isn’t called, so emitted data is wrong. _(Label: Bug)_
 - [ ] **Pause button permanently kills the game loop** – `updateGameState` returns `null` when paused, and the multiplayer loop treats it as game over, so play never resumes. _(Label: Bug)_
 - [ ] **Staked match winners never receive claim signatures** – The multiplayer flow updates `Game` records without calling `signatureService`, leaving `winnerSignature` empty and wins unclaimable. _(Label: Bug)_


### PR DESCRIPTION
 ## Summary
  - add backend socket-event constants + helper so both `leaderboardUpdate` and its `rankingsUpdate` alias fire whenever the leaderboard changes
  - introduce a shared frontend hook/state to subscribe to both events, dedupe payloads, and show a badge explaining which event powered the latest standings
  - document the aliasing/debug env vars (including a new socket-events reference) and mark the tracker issue resolved

  ## Testing
  n/a – wiring/docs only
